### PR TITLE
fix(dup3): use os instead of ioutil

### DIFF
--- a/ch01/dup3/main.go
+++ b/ch01/dup3/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -10,7 +9,7 @@ import (
 func main() {
 	counts := make(map[string]int)
 	for _, filename := range os.Args[1:] {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dup3: %v\n", err)
 			continue

--- a/ch01/pr_1_4/main.go
+++ b/ch01/pr_1_4/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -15,7 +14,7 @@ type dup struct {
 func main() {
 	counts := make(map[string]*dup)
 	for _, filename := range os.Args[1:] {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dup3: %v\n", err)
 			continue


### PR DESCRIPTION
Use os package instead of ioutil package because ioutil package was deprecated.